### PR TITLE
Adding missing dependencies to build.md

### DIFF
--- a/documentation/developer/build.md
+++ b/documentation/developer/build.md
@@ -16,7 +16,7 @@ First install some basic dependencies:
 ```bash
 %> sudo yum install git perl perl-Module-Install automake gperf gcc-c++ \
      autoconf libtool gd-devel expat-devel mysql-devel rpm-build \
-     wget httpd
+     wget httpd tar logrotate help2man libicu-devel
 ```
 
 Then clone our repository in any folder you like:


### PR DESCRIPTION
Added needed dependencies: tar logrotate help2man libicu-devel.  
- The initial `./configure` using the yum dependencies on this page resulted in this, which was resolved by installing `tar`:

```
[root@aa7f309da429 naemon]# ./configure 
libtoolize: putting auxiliary files in `.'.
libtoolize: can not copy `/usr/share/libtool/config/ltmain.sh' to `./'
libtoolize: Consider adding `AC_CONFIG_MACRO_DIR([m4])' to configure.ac and
libtoolize: rerunning libtoolize, to keep the correct libtool macros in-tree.
libtoolize: Consider adding `-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
autoreconf: libtoolize failed with exit status: 1
```
- `make rpm` then failed with the following:

```
error: Failed build dependencies:
    logrotate is needed by naemon-1.0.0-1.el6.x86_64
    help2man is needed by naemon-1.0.0-1.el6.x86_64
    libicu-devel is needed by naemon-1.0.0-1.el6.x86_64
make: *** [rpm] Error 1
```

Added yum, logrotate, help2man, and libicu-devel to the documentation.
